### PR TITLE
Remove unused robot ids

### DIFF
--- a/src/main/java/frc/robot/Config.java
+++ b/src/main/java/frc/robot/Config.java
@@ -84,9 +84,6 @@ public final class Config {
    * ID 1: Clutch (Rapid React)
    * ID 2: Beetle (Small Talon tank drive)
    * ID 3: Cosmobot (Deep Space)
-   * ID 4: MiniSwerve (Small swerve chassis)
-   * ID 5: NeoBeetle (Small Neo tank drive)
-   * ID 6: ArmBot (Arm Bot)
    * 
    * ...
    * 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,9 +8,9 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
-import frc.robot.robotcontainers.ArmBotContainer;
 import frc.robot.robotcontainers.BeetleContainer;
 import frc.robot.robotcontainers.ClutchContainer;
+import frc.robot.robotcontainers.CosmobotContainer;
 import frc.robot.robotcontainers.PoseidonContainer;
 import frc.robot.robotcontainers.RobotContainer;
 
@@ -48,17 +48,8 @@ public class Robot extends TimedRobot {
       case 2:
         m_robotContainer = new BeetleContainer(); break;
 
-      // case 3:
-      //   m_robotContainer = new MergonautContainer(); break;
-
-      // case 4:
-      //   m_robotContainer = new MiniSwerveContainer(); break;
-
-      // case 5:
-      //   m_robotContainer = new MiniNeoDiffContainer(); break;
-      
-      case 6:
-        m_robotContainer = new ArmBotContainer(); break;
+      case 3:
+        m_robotContainer = new CosmobotContainer(); break;
 
       default:
         m_robotContainer = new PoseidonContainer();

--- a/src/main/java/frc/robot/commands/ExampleCommand.java
+++ b/src/main/java/frc/robot/commands/ExampleCommand.java
@@ -1,0 +1,32 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+
+public class ExampleCommand extends CommandBase {
+  /** Creates a new ExampleCommand. */
+  public ExampleCommand() {
+    // Use addRequirements() here to declare subsystem dependencies.
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {}
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/robotcontainers/CosmobotContainer.java
+++ b/src/main/java/frc/robot/robotcontainers/CosmobotContainer.java
@@ -6,8 +6,8 @@ package frc.robot.robotcontainers;
 
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.livewindow.LiveWindow;
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.Robot;
 
@@ -17,16 +17,12 @@ import frc.robot.Robot;
  * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
  * subsystems, commands, and button mappings) should be declared here.
  */
-public class ArmBotContainer extends RobotContainer{
-
+public class CosmobotContainer extends RobotContainer {
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
-  public ArmBotContainer() {
+  public CosmobotContainer() {
     // Configure the button bindings
-    LiveWindow.enableAllTelemetry();
-
     configureButtonBindings();
-    
   }
 
   /**
@@ -37,9 +33,8 @@ public class ArmBotContainer extends RobotContainer{
    */
   private void configureButtonBindings() {
     CommandXboxController driver = new CommandXboxController(0);
-    CommandXboxController controlStick = new CommandXboxController(1);
+    CommandXboxController operator = new CommandXboxController(1);
   }
-
 
   /**
    * Use this to pass the autonomous command to the main {@link Robot} class.
@@ -48,8 +43,6 @@ public class ArmBotContainer extends RobotContainer{
    */
   @Override
   public Command getAutonomousCommand() {
-    return null;
+    return new InstantCommand(); 
   }
-
-
 }

--- a/src/main/java/frc/robot/subsystems/ExampleSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ExampleSubsystem.java
@@ -1,0 +1,17 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class ExampleSubsystem extends SubsystemBase {
+  /** Creates a new ExampleSubsystem. */
+  public ExampleSubsystem() {}
+
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+  }
+}


### PR DESCRIPTION
Remove robot ids that belong to robots that are dead. Gone forever. Ripped apart mercilessly.


Closes #18.